### PR TITLE
fix: correct GitHub language detection to show Go

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-# Mark scripts as vendored so GitHub language detection focuses on Go code
+# Mark scripts as vendored so Go is the primary language
 *.ps1 linguist-vendored
 *.sh linguist-vendored

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,7 @@
+// Package main provides examples for running Go functions on Azure Functions.
+//
+// This project demonstrates the Custom Handler pattern for Azure Functions,
+// allowing you to write functions in Go using standard net/http.
+//
+// See the samples directory for complete working examples.
+package main


### PR DESCRIPTION
Add doc.go at root and vendor scripts so GitHub shows Go as the primary language.